### PR TITLE
Update minor version number to disambiguate from old mercurial repo.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,7 @@
 7.0.0 (2013-06-19):
 * Initial public release
+
+7.1.0 (2013-08-09):
+* Update minor number to disambiguate new builds from builds of the
+  old mercurial repo.
+

--- a/build.py
+++ b/build.py
@@ -294,7 +294,7 @@ if __name__ == '__main__':
         revision.close()
 
     os.environ['MAJOR_VERSION'] = '7'
-    os.environ['MINOR_VERSION'] = '0'
+    os.environ['MINOR_VERSION'] = '1'
     os.environ['MICRO_VERSION'] = '0'
 
     if 'BUILD_NUMBER' not in os.environ.keys():

--- a/clean.py
+++ b/clean.py
@@ -2,7 +2,7 @@
 
 import os, sys
 
-file = os.popen('hg status')
+file = os.popen('git status -u --porcelain')
 
 for line in file:
     item = line.split(' ')


### PR DESCRIPTION
Update minor number to disambiguate new builds from builds of the old mercurial repo.
Update the clean.py script to use git commands

signed-off-by: Owen Smith owen.smith@citrix.com
