### PR TITLE
Fix potential interrupt storm

### DIFF
--- a/src/xenbus/evtchn.h
+++ b/src/xenbus/evtchn.h
@@ -58,6 +58,16 @@ EvtchnInterrupt(
     );
 
 extern VOID
+EvtchnEnable(
+    IN  PXENBUS_EVTCHN_INTERFACE    Interface
+    );
+
+extern VOID
+EvtchnDisable(
+    IN  PXENBUS_EVTCHN_INTERFACE    Interface
+    );
+
+extern VOID
 EvtchnTeardown(
     IN OUT  PXENBUS_EVTCHN_INTERFACE    Interface
     );


### PR DESCRIPTION
Enable and disable callback via at source rather than
trying to keep a local disabled flag for the interrupt.
If we don't do this we can get into a interrupt storm on
startup.

Signed-off-by: Paul Durrant paul.durrant@citrix.com
