### PR TITLE
Reserve an entry of the grant table for the crash kernel. Not doing this

### DIFF
--- a/src/xenbus/gnttab.c
+++ b/src/xenbus/gnttab.c
@@ -43,7 +43,9 @@
 #define GNTTAB_MAXIMUM_FRAME_COUNT    32
 #define GNTTAB_ENTRY_PER_FRAME              (PAGE_SIZE / sizeof (grant_entry_v1_t))
 
-#define GNTTAB_RESERVED_ENTRY_COUNT 8
+// Xen requires that we avoid the first 8 entries of the table and
+// we also reserve 1 entry for the crash kernel
+#define GNTTAB_RESERVED_ENTRY_COUNT 9
 
 #define GNTTAB_INVALID_REFERENCE    0
 


### PR DESCRIPTION
seems to cause crashdumps to fail in some circumstances.

Signed-off-by: Paul Durrant paul.durrant@citrix.com
