### PR TITLE
[SCTX-1104] Add WindowsPEMode to xenfilt

### DIFF
--- a/src/xenfilt/fdo.c
+++ b/src/xenfilt/fdo.c
@@ -232,6 +232,47 @@ __FdoGetPhysicalDeviceObject(
     return Fdo->PhysicalDeviceObject;
 }
 
+
+static FORCEINLINE NTSTATUS
+__FdoSetWindowsPEPrefix(
+    IN  PXENFILT_FDO    Fdo
+    )
+{
+    HANDLE                  ServiceKey;
+    DWORD                   WindowsPEMode;
+    NTSTATUS                status;
+
+    status = RegistryOpenServiceKey(KEY_READ,
+                                    &ServiceKey);
+    if (!NT_SUCCESS(status))
+        goto fail1;
+
+    status = RegistryQueryDwordValue(ServiceKey,
+                                     "WindowsPEMode",
+                                     &WindowsPEMode);
+    if (!NT_SUCCESS(status))
+        goto fail2;
+
+    if (!WindowsPEMode)
+        goto fail3;
+
+    Fdo->Prefix[0]=0;
+
+    return STATUS_SUCCESS;
+
+fail3:
+    Error("fail3\n");
+
+fail2:
+    Error("fail2\n");
+    RegistryCloseKey(ServiceKey);
+
+fail1:
+    Error("fail1\n");
+
+    return status;
+}
+
 static FORCEINLINE NTSTATUS
 __FdoSetPrefix(
     IN  PXENFILT_FDO        Fdo
@@ -1981,6 +2022,8 @@ FdoCreate(
     __FdoSetName(Fdo, Name);
 
     status = __FdoSetPrefix(Fdo);
+    if (!NT_SUCCESS(status))
+        status = __FdoSetWindowsPEPrefix(Fdo);
     if (!NT_SUCCESS(status))
         goto fail6;
 


### PR DESCRIPTION
ParentIdPrefixes are not avilable at Windows PE driver filtering time,
but we don't actually need them if we know emulated devices will be
unplugged, so, if ParentIdPrefix can't be read from the registry and
HKLM\System\CurrentControlSet\Services\xenfilt\WindowsPEMode is set to 1
then just set the prefix to be an empty string and continue

We never set WindowsPEMode anywhere except in the sample Windows PE
scripts, so non-WindowsPE environments are unaffected

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
