### PR TITLE
Add error path to RangeSetPop()

### DIFF
--- a/src/xenbus/balloon.c
+++ b/src/xenbus/balloon.c
@@ -414,8 +414,15 @@ __BalloonPopulatePfnArray(
 
     KeQuerySystemTime(&Start);
 
-    for (Index = 0; Index < Requested; Index++)
-        Balloon->PfnArray[Index] = (PFN_NUMBER)RangeSetPop(Balloon->RangeSet);
+    for (Index = 0; Index < Requested; Index++) {
+        ULONGLONG   Pfn;
+        NTSTATUS    status;
+
+        status = RangeSetPop(Balloon->RangeSet, &Pfn);
+        ASSERT(NT_SUCCESS(status));
+
+        Balloon->PfnArray[Index] = (PFN_NUMBER)Pfn;
+    }
 
     Count = __BalloonPopulatePhysmap(Requested, Balloon->PfnArray);
 

--- a/src/xenbus/gnttab.c
+++ b/src/xenbus/gnttab.c
@@ -136,6 +136,7 @@ GnttabDescriptorCtor(
 {
     PXENBUS_GNTTAB_CONTEXT      Context = Argument;
     PXENBUS_GNTTAB_DESCRIPTOR   Descriptor = Object;
+    ULONGLONG                   Reference;
     NTSTATUS                    status;
 
     if (!RangeSetIsEmpty(Context->RangeSet))
@@ -146,9 +147,16 @@ GnttabDescriptorCtor(
         goto fail1;
 
 done:
-    Descriptor->Reference = (ULONG)RangeSetPop(Context->RangeSet);
+    status = RangeSetPop(Context->RangeSet, &Reference);
+    if (!NT_SUCCESS(status))
+        goto fail2;
+
+    Descriptor->Reference = (ULONG)Reference;
 
     return STATUS_SUCCESS;
+
+fail2:
+    Error("fail2\n");
 
 fail1:
     Error("fail1 (%08x)\n", status);

--- a/src/xenbus/range_set.h
+++ b/src/xenbus/range_set.h
@@ -41,9 +41,10 @@ RangeSetIsEmpty(
     IN  PXENBUS_RANGE_SET   RangeSet
     );
 
-extern ULONGLONG
+extern NTSTATUS
 RangeSetPop(
-    IN  PXENBUS_RANGE_SET   RangeSet
+    IN  PXENBUS_RANGE_SET   RangeSet,
+    OUT PULONGLONG          Item
     );
 
 extern NTSTATUS


### PR DESCRIPTION
Now that RangeSetPop() is being used to backend grant table allocations
it's legitimate for it to fail.

Signed-off-by: Paul Durrant paul.durrant@citrix.com
