### PR TITLE
RangeSet fixes

### DIFF
--- a/src/xenbus/balloon.c
+++ b/src/xenbus/balloon.c
@@ -415,7 +415,7 @@ __BalloonPopulatePfnArray(
     KeQuerySystemTime(&Start);
 
     for (Index = 0; Index < Requested; Index++) {
-        ULONGLONG   Pfn;
+        LONGLONG    Pfn;
         NTSTATUS    status;
 
         status = RangeSetPop(Balloon->RangeSet, &Pfn);
@@ -431,8 +431,8 @@ __BalloonPopulatePfnArray(
         NTSTATUS    status;
 
         status = RangeSetPut(Balloon->RangeSet,
-                             (ULONGLONG)Balloon->PfnArray[Index],
-                             (ULONGLONG)Balloon->PfnArray[Index]);
+                             (LONGLONG)Balloon->PfnArray[Index],
+                             (LONGLONG)Balloon->PfnArray[Index]);
         ASSERT(NT_SUCCESS(status));
 
         Balloon->PfnArray[Index] = 0;
@@ -511,8 +511,8 @@ __BalloonReleasePfnArray(
         }
 
         status = RangeSetPut(Balloon->RangeSet,
-                             (ULONGLONG)Balloon->PfnArray[Index],
-                             (ULONGLONG)Balloon->PfnArray[Next]);
+                             (LONGLONG)Balloon->PfnArray[Index],
+                             (LONGLONG)Balloon->PfnArray[Next]);
         if (!NT_SUCCESS(status))
             break;
 
@@ -532,7 +532,7 @@ __BalloonReleasePfnArray(
     for (Index = Count; Index < Requested; Index++) {
         NTSTATUS    status;
 
-        status = RangeSetGet(Balloon->RangeSet, (ULONGLONG)Balloon->PfnArray[Index]);
+        status = RangeSetGet(Balloon->RangeSet, (LONGLONG)Balloon->PfnArray[Index]);
         ASSERT(NT_SUCCESS(status));
 
         Balloon->PfnArray[Index] = 0;

--- a/src/xenbus/gnttab.c
+++ b/src/xenbus/gnttab.c
@@ -136,7 +136,7 @@ GnttabDescriptorCtor(
 {
     PXENBUS_GNTTAB_CONTEXT      Context = Argument;
     PXENBUS_GNTTAB_DESCRIPTOR   Descriptor = Object;
-    ULONGLONG                   Reference;
+    LONGLONG                    Reference;
     NTSTATUS                    status;
 
     if (!RangeSetIsEmpty(Context->RangeSet))

--- a/src/xenbus/range_set.h
+++ b/src/xenbus/range_set.h
@@ -44,20 +44,20 @@ RangeSetIsEmpty(
 extern NTSTATUS
 RangeSetPop(
     IN  PXENBUS_RANGE_SET   RangeSet,
-    OUT PULONGLONG          Item
+    OUT PLONGLONG           Item
     );
 
 extern NTSTATUS
 RangeSetGet(
     IN  PXENBUS_RANGE_SET   RangeSet,
-    IN  ULONGLONG           Item
+    IN  LONGLONG            Item
     );
 
 extern NTSTATUS
 RangeSetPut(
     IN  PXENBUS_RANGE_SET   RangeSet,
-    IN  ULONGLONG           Start,
-    IN  ULONGLONG           End
+    IN  LONGLONG            Start,
+    IN  LONGLONG            End
     );
 
 extern NTSTATUS


### PR DESCRIPTION
- add spinlock to protect rangesets.
- add a Count value to check against empty condition in audit.
- use LONGLONG in ranges rather than ULONGLONG so that ranges can be
  invalidated by setting Start > End.

(Auditing is on even for free builds for now. It can be turned off after successful BVT and BST).

Signed-off-by: Paul Durrant paul.durrant@citrix.com
