### PR TITLE
Fix 0xC4 BSOD from Pool code.

### DIFF
--- a/src/xenbus/pool.c
+++ b/src/xenbus/pool.c
@@ -428,7 +428,7 @@ __PoolTrimShared(
 
     KeMemoryBarrier();
 
-    Excess = __min((LONG)Pool->MinimumPopulation - (LONG)Pool->Reservation, 0);
+    Excess = __max((LONG)Pool->MinimumPopulation - (LONG)Pool->Reservation, 0);
     
     while (Excess != 0) {
         PLIST_ENTRY     ListEntry;


### PR DESCRIPTION
__PoolTrimShared would not trim any pool allocations

Signed-off-by: Owen Smith owen.smith@citrix.com
