### PR TITLE
[CP-10562] Add 2 New patchqueue commands:

### DIFF
--- a/addpatch.py
+++ b/addpatch.py
@@ -1,0 +1,37 @@
+import sys
+import patchqueue
+import xspatchq.gittool as xsgittool
+
+def addpatch(newfilename):
+    newqueue = open ('patchqueue.py','w')
+    
+    print("remoterepo = r\""+patchqueue.remoterepo+"\"", file=newqueue)
+    print("baserepo = r\""+patchqueue.baserepo+"\"", file=newqueue)
+    print("basetag = r\""+patchqueue.basetag+"\"", file=newqueue)
+    print("package = r\""+patchqueue.package+"\"", file=newqueue)
+    
+    print("components = [", file=newqueue)
+    for component in patchqueue.components:
+        print("\tr\""+component+"\",", file=newqueue)
+    print("\t]", file=newqueue)
+    print("sdv_components = [", file=newqueue)
+    for component in patchqueue.sdv_components:
+        print("\tr\""+component+"\",", file=newqueue)
+    print("\t]", file=newqueue)
+    print("patchlist = [", file=newqueue)
+    
+    newlist = patchqueue.patchlist
+    
+    newlist.append(newfilename)
+    
+    for patch in patchqueue.patchlist:
+        print("\tr\""+patch+"\",", file=newqueue)
+    print("\t]", file=newqueue)
+    xsgittool.add(newfilename)
+    xsgittool.add("patchqueue.py")
+    
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print("Usage:  addpatch <patchfilename>")
+        exit(1)
+    addpatch(sys.argv[1])

--- a/build.py
+++ b/build.py
@@ -4,6 +4,7 @@ import os, sys
 import xspatchq.buildtool as xsbuildtool
 import xspatchq.symstore as xssymstore
 import xspatchq.msvc as xsmsvc
+import xspatchq.gittool as xsgittool
 import patchqueue
 import checkout
 
@@ -44,6 +45,11 @@ if __name__ == '__main__':
         checkout.clone_apply_patchqueue()
 
     os.chdir(patchqueue.package)
+    if (xsgittool.needsrebase(patchqueue.basetag)):
+        print ("This build needs to be reset to access revision "+patchqueue.basetag)
+        print ("Ensure "+patchqueue.package+" is deleted or renamed, and run rebase if neccessary")
+        sys.exit(1)
+
     os.makedirs(patchqueue.package, exist_ok=True)
     
     xsbuildtool.archive(
@@ -58,7 +64,7 @@ if __name__ == '__main__':
     xssymstore.add(patchqueue.package, release, 'x64', debug[sys.argv[1]], vs)
 
     if len(sys.argv) <= 2 or sdv[sys.argv[2]]:
-        for component in patchqueue.components:
+        for component in patchqueue.sdv_components:
             xsmsvc.run_sdv(component, patchqueue.package, vs)
 
     xsbuildtool.archive(buildwd+'\\'+patchqueue.package + '.tar', [patchqueue.package,'revision'])

--- a/patchqueue.py
+++ b/patchqueue.py
@@ -1,40 +1,17 @@
-# Copyright (c) Citrix Systems Inc.
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, 
-# with or without modification, are permitted provided 
-# that the following conditions are met:
-#
-# *   Redistributions of source code must retain the above 
-#     copyright notice, this list of conditions and the 
-#     following disclaimer.
-# *   Redistributions in binary form must reproduce the above 
-#     copyright notice, this list of conditions and the 
-#     following disclaimer in the documentation and/or other 
-#     materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-# SUCH DAMAGE.
-
-baserepo = "git://hg.uk.xensource.com/closed/windows/xenbits/win-xenbus.git"
-
-basetag = "18b586a9ea03730183053046f35d974a8991fb68"
-
-package = "xenbus"
-
-components = ["xen", "xenfilt", "xenbus"]
-
-patchlist = []
-
+remoterepo = r"git://xenbits.xen.org/pvdrivers/win/xenbus.git"
+baserepo = r"ssh://xenhg@hg.uk.xensource.com/closed/windows/xenbits/win-xenbus.git"
+basetag = r"18b586a9ea03730183053046f35d974a8991fb68"
+package = r"xenbus"
+components = [
+	r"xen",
+	r"xenbus",
+	r"xenfilt",
+	r"coinst",
+	]
+sdv_components = [
+	r"xen",
+	r"xenbus",
+	r"xenfilt",
+	]
+patchlist = [
+	]

--- a/rebase.py
+++ b/rebase.py
@@ -1,0 +1,44 @@
+import xspatchq.gittool as xsgittool
+import patchqueue
+import os
+import sys
+import posixpath
+import shutil
+
+def rebase():
+
+    xsgittool.clone(patchqueue.baserepo, 'rebasequeue')
+
+    pregitdir = os.getcwd()
+    os.chdir('rebasequeue')
+
+    if ( xsgittool.needsrebase(patchqueue.basetag)):
+        print ("I SHOULD REBASE")
+        xsgittool.pull(patchqueue.remoterepo,'master:master')
+        xsgittool.resethard(patchqueue.basetag)
+        print("and push")
+        xsgittool.pushforce(patchqueue.baserepo)
+        if os.path.exists(patchqueue.package):
+            count = 0
+            rebasename=""
+            while True:
+                rebasename = patchqueue.package+".rebase."+count
+                if (not os.path.exists(rebasename)):
+                    break;
+                count+=1
+            os.rename(patchqueue.package,rebasename)
+    os.chdir(pregitdir)
+
+if __name__ == '__main__':
+    rebase()
+    if os.path.exists(patchqueue.package):
+        print("Package")
+        count = 0
+        rebasename=""
+        while True:
+            rebasename = patchqueue.package+".rebase."+str(count)
+            if (not os.path.exists(rebasename)):
+                break;
+            count+=1
+        os.rename(patchqueue.package,rebasename)
+

--- a/xspatchq/gittool.py
+++ b/xspatchq/gittool.py
@@ -4,6 +4,11 @@ import shutil
 import xspatchq.buildtool as xsbuildtool
 import stat
 
+def needsrebase(tag):
+    if (not contains(tag)):
+        return True
+    return False
+
 def remove_readonly(func, path, execinfo):
     os.chmod(path, stat.S_IWRITE)
     os.unlink(path)
@@ -12,6 +17,14 @@ def apply(patchname):
     res = xsbuildtool.shell(['git', 'am', patchname], None)
     if res != 0 :
         raise Exception("git am "+patchname+" returned ", res)
+
+def clone(repo, destination):
+    if os.path.exists(destination):
+        print ("removing "+destination)
+        shutil.rmtree(destination, onerror=remove_readonly)
+    res = xsbuildtool.shell(['git','clone',repo, destination], None)
+    if res != 0:
+        raise Exception("git clone "+repo+" "+destination+" returned :", res)
 
 def clone_to(repo, tag, destination):
     if os.path.exists(destination):
@@ -22,3 +35,22 @@ def clone_to(repo, tag, destination):
     res = xsbuildtool.shell(['git','checkout',tag], destination)
     if res != 0:
         raise Exception("git checkout "+tag+" returned :", res)
+
+def add(filename):
+    xsbuildtool.shell(['git','add',filename], None)
+
+def resethard(tag):
+    xsbuildtool.shell(['git','reset','--hard', tag], None)
+
+def pull(repo,spec):
+    xsbuildtool.shell(['git','pull',repo,spec],None)
+
+def push(repo):
+	xsbuildtool.shell(['git','push',repo,"master:master"],None)
+
+def pushforce(repo):
+	xsbuildtool.shell(['git','push','-f',repo,"master:master"],None)
+
+def contains(tag):
+    res = xsbuildtool.shell(['git','merge-base','--is-ancestor',tag,'HEAD'],None)
+    return (res == 0) 


### PR DESCRIPTION
rebase.py
  rebases the baserepro to the basetag from the remoterepo
  (remoterepo being the upstream repo on xenbits,
   baserepo being a local copy of the upstream repo)

addpatch.py
  adds a patch file to the patchqueue.py patchlist
  "git add"s the patch and patchqueue.py

build.py now warns you when you need to rebase

Also explicitly build but dont sdv the coinstaller

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
